### PR TITLE
Use plotly for sub heatmap

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: person("Zuguang", "Gu", email = "z.gu@dkfz.de", role = c("aut", "cre"
 Depends: R (>= 4.0.0), ComplexHeatmap (>= 2.11.0)
 Imports: grDevices, stats, shiny (>= 1.7.4), grid, GetoptLong, 
     S4Vectors (>= 0.26.1), digest, IRanges, kableExtra (>= 1.3.1), utils, svglite,
-    htmltools (>= 0.5.4), clisymbols, jsonlite, RColorBrewer, fontawesome, shinycssloaders, bslib (>= 0.4.2),
+    htmltools (>= 0.5.4), clisymbols, jsonlite, RColorBrewer, fontawesome, shinycssloaders,
     shinyjs, plotly
 Suggests: knitr, rmarkdown, testthat, EnrichedHeatmap, GenomicRanges, data.table,
     circlize, GenomicFeatures, tidyverse, tidyHeatmap, cluster,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,12 +8,13 @@ Authors@R: person("Zuguang", "Gu", email = "z.gu@dkfz.de", role = c("aut", "cre"
 Depends: R (>= 4.0.0), ComplexHeatmap (>= 2.11.0)
 Imports: grDevices, stats, shiny (>= 1.7.4), grid, GetoptLong, 
     S4Vectors (>= 0.26.1), digest, IRanges, kableExtra (>= 1.3.1), utils, svglite,
-    htmltools (>= 0.5.4), clisymbols, jsonlite, RColorBrewer, fontawesome, shinycssloaders, bslib (>= 0.4.2)
+    htmltools (>= 0.5.4), clisymbols, jsonlite, RColorBrewer, fontawesome, shinycssloaders, bslib (>= 0.4.2),
+    shinyjs, plotly
 Suggests: knitr, rmarkdown, testthat, EnrichedHeatmap, GenomicRanges, data.table,
     circlize, GenomicFeatures, tidyverse, tidyHeatmap, cluster,
     org.Hs.eg.db, simplifyEnrichment, GO.db, SC3, GOexpress, SingleCellExperiment,
     scater, gplots, pheatmap, airway, DESeq2, DT, cola, BiocManager, gridtext,
-    HilbertCurve (>= 1.21.1), shinydashboard, SummarizedExperiment, pkgndep, ks, shinyjs
+    HilbertCurve (>= 1.21.1), shinydashboard, SummarizedExperiment, pkgndep, ks
 VignetteBuilder: knitr
 Description: This package can easily make heatmaps which are produced 
     by the ComplexHeatmap package into interactive applications. It provides two types of interactivities: 

--- a/R/shiny-server.R
+++ b/R/shiny-server.R
@@ -1966,6 +1966,10 @@ record_observation = function(obs, heatmap_id = shiny_env$current_heatmap_id) {
 make_plotly_sub_heatmap = function(input, output, session, heatmap_id, update_size = TRUE, 
 	selected = NULL, ht_list = NULL, ...) {
 
+	# message("SUBHEATMAP SELECTED()")
+	# str(selected(),3)
+	# message("SUBHEATMAP HT_LIST()")
+	# str(ht_list(),3)
 	if(is.null( selected() ))
 		return(NULL)
 
@@ -2002,7 +2006,7 @@ make_plotly_sub_heatmap = function(input, output, session, heatmap_id, update_si
 .make_plotly_sub_heatmap <- function(ht_list, selected) {
 	.r <- rev(selected()@listData$row_label@unlistData) # target
 	.c <- selected()@listData$column_label@unlistData # sample
-	.m_full <- ht_list()@ht_list$mat@matrix
+	.m_full <- ht_list()@ht_list[[1]]@matrix
 	.m <- .m_full[.r,.c] # value
 	.i <- paste0("Target: ", rep(.r, length(.c)), "\nSample: ", rep(.c, each=length(.r)), "\nValue: ", round(as.numeric(.m), 2))
 	dim(.i) <- dim(.m)

--- a/R/shiny-server.R
+++ b/R/shiny-server.R
@@ -2014,6 +2014,8 @@ make_plotly_sub_heatmap = function(input, output, session, heatmap_id, update_si
 		hoverinfo = 'text', text = .i) |>
 		plotly::colorbar(thickness = 15, outlinewidth = 0, x = -0.5) |>
 		plotly::config(displayModeBar = FALSE) |>
-		plotly::layout(yaxis = list(side = "right"))
+		plotly::layout(
+			yaxis = list(side = "right"),
+			hoverlabel = list(align = "left", font = list(size = 12)))
 	.p
 }

--- a/R/shiny-server.R
+++ b/R/shiny-server.R
@@ -41,7 +41,7 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 	heatmap_id = shiny_env$current_heatmap_id,
 	click_action = NULL, hover_action = NULL, 
 	dblclick_action = NULL, brush_action = NULL, res = 72,
-	show_cell_fun = TRUE, show_layer_fun = TRUE) {
+	show_cell_fun = TRUE, show_layer_fun = TRUE, plotly = FALSE) {
 
 	if(shiny_env$heatmap[[heatmap_id]]$action == "hover") {
 		if(!is.null(hover_action)) click_action = hover_action
@@ -341,11 +341,19 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 		    heatmap_initialized(TRUE)
 		}, res = res)
 
-		output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
-			grid.newpage()
-			grid.text("Select an area of the heatmap", 0.5, 0.5, gp = gpar(fontsize = 14))
 
-		}, res = res)
+		message("(0)")
+		if (plotly) {
+			output[[qq("@{heatmap_id}_sub_heatmap")]] = plotly::renderPlotly({
+				NULL
+			})
+		} else {
+			output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+				grid.newpage()
+				grid.text("Select an area of the heatmap", 0.5, 0.5, gp = gpar(fontsize = 14))
+			}, res = res)
+		}
+
 
 		if(do_default_click_action || do_default_brush_action) {
 			output[[qq("@{heatmap_id}_info")]] = renderUI({
@@ -463,15 +471,23 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 
 			updateTextInput(session, qq("@{heatmap_id}_keyword"), value = "")
 
-			output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
-				
-	    		if(is.null( selected() )) {
-	    			grid.newpage()
-					grid.text("Select an area of the heatmap", 0.5, 0.5, gp = gpar(fontsize = 14))
-	    		} else {
-	    			sub_ht_list( make_sub_heatmap(input, output, session, heatmap_id, selected = selected(), ht_list = ht_list()) )
-				}
-			}, res = res)
+			message("(1)")
+			if (plotly) {
+				# output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot(plot(0))
+				output[[qq("@{heatmap_id}_sub_heatmap")]] = plotly::renderPlotly({
+					make_plotly_sub_heatmap(input, output, session, heatmap_id, selected = selected, ht_list = ht_list)
+				})
+			} else {
+				output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+					
+					if(is.null( selected() )) {
+						grid.newpage()
+						grid.text("Select an area of the heatmap", 0.5, 0.5, gp = gpar(fontsize = 14))
+					} else {
+						sub_ht_list( make_sub_heatmap(input, output, session, heatmap_id, selected = selected(), ht_list = ht_list()) )
+					}
+				}, res = res)
+			}
 		
 			if(do_default_brush_action) {
 				default_brush_action(input, output, session, heatmap_id, selected = selected(), ht_list = ht_list())
@@ -499,15 +515,23 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 
 			selected(new_selected)
 
-			output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
-				
-	    		if(nrow( selected() ) == 0) {
-	    			grid.newpage()
-					grid.text("No row/column is left.\nPlease change to a smaller number to remove.", 0.5, 0.5, gp = gpar(fontsize = 14))
-	    		} else {
-	    			sub_ht_list( make_sub_heatmap(input, output, session, heatmap_id, selected = selected(), ht_list = ht_list()) )
-				}
-			}, res = res)
+			message("(2)")
+			if (plotly) {
+				# output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot(plot(0))
+				output[[qq("@{heatmap_id}_sub_heatmap")]] = plotly::renderPlotly({
+					make_plotly_sub_heatmap(input, output, session, heatmap_id, selected = selected, ht_list = ht_list)
+				})
+			} else {
+				output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+					
+					if(nrow( selected() ) == 0) {
+						grid.newpage()
+						grid.text("No row/column is left.\nPlease change to a smaller number to remove.", 0.5, 0.5, gp = gpar(fontsize = 14))
+					} else {
+						sub_ht_list( make_sub_heatmap(input, output, session, heatmap_id, selected = selected(), ht_list = ht_list()) )
+					}
+				}, res = res)
+			}
 		
 			if(do_default_brush_action) {
 				default_brush_action(input, output, session, heatmap_id, selected = selected(), ht_list = ht_list())
@@ -536,15 +560,23 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 				selected( selected_copy() )
 			}
 			
-			output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
-				
-	    		if(nrow( selected() ) == 0) {
-	    			grid.newpage()
-					grid.text("All empty rows/columns are removed.", 0.5, 0.5, gp = gpar(fontsize = 14))
-	    		} else {
-	    			sub_ht_list( make_sub_heatmap(input, output, session, heatmap_id, selected = selected(), ht_list = ht_list()) )
-				}
-			}, res = res)
+			message("(3)")
+			if (plotly) {
+				# output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot(plot(0))
+				output[[qq("@{heatmap_id}_sub_heatmap")]] = plotly::renderPlotly({
+					make_plotly_sub_heatmap(input, output, session, heatmap_id, selected = selected, ht_list = ht_list)
+				})
+			} else {
+				output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+					
+					if(nrow( selected() ) == 0) {
+						grid.newpage()
+						grid.text("All empty rows/columns are removed.", 0.5, 0.5, gp = gpar(fontsize = 14))
+					} else {
+						sub_ht_list( make_sub_heatmap(input, output, session, heatmap_id, selected = selected(), ht_list = ht_list()) )
+					}
+				}, res = res)
+			}
 		
 			if(do_default_brush_action) {
 				default_brush_action(input, output, session, heatmap_id, selected = selected(), ht_list = ht_list())
@@ -567,15 +599,23 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 
 			selected( selected_copy() )
 
-			output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
-				
-	    		if(is.null( selected() )) {
-	    			grid.newpage()
-					grid.text("Select an area of the heatmap", 0.5, 0.5, gp = gpar(fontsize = 14))
-	    		} else {
-	    			sub_ht_list( make_sub_heatmap(input, output, session, heatmap_id, selected = selected(), ht_list = ht_list()) )
-				}
-			}, res = res)
+			message("(4)")
+			if (plotly) {
+				# output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot(plot(0))
+				output[[qq("@{heatmap_id}_sub_heatmap")]] = plotly::renderPlotly({
+					make_plotly_sub_heatmap(input, output, session, heatmap_id, selected = selected, ht_list = ht_list)
+				})
+			} else {
+				output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+					
+					if(is.null( selected() )) {
+						grid.newpage()
+						grid.text("Select an area of the heatmap", 0.5, 0.5, gp = gpar(fontsize = 14))
+					} else {
+						sub_ht_list( make_sub_heatmap(input, output, session, heatmap_id, selected = selected(), ht_list = ht_list()) )
+					}
+				}, res = res)
+			}
 		
 			if(do_default_brush_action) {
 				default_brush_action(input, output, session, heatmap_id, selected = selected(), ht_list = ht_list())
@@ -672,24 +712,32 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 			}
 			selected_copy( selected() )
 
-			output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
-				
-	    		if(is.null(selected())) {
-	    			grid.newpage()
-					grid.text(paste(strwrap(qq("Found nothing from heatmaps with keywords '@{keywords2}'."), width = 60), collapse = "\n"), 0.5, 0.5, gp = gpar(fontsize = 14, col = "red"))
+			message("(5)")
+			if (plotly) {
+				# output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot(plot(0))
+				output[[qq("@{heatmap_id}_sub_heatmap")]] = plotly::renderPlotly({
+					make_plotly_sub_heatmap(input, output, session, heatmap_id, selected = selected, ht_list = ht_list)
+				})
+			} else {
+				output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+					
+					if(is.null(selected())) {
+						grid.newpage()
+						grid.text(paste(strwrap(qq("Found nothing from heatmaps with keywords '@{keywords2}'."), width = 60), collapse = "\n"), 0.5, 0.5, gp = gpar(fontsize = 14, col = "red"))
 
-					if(do_default_brush_action) {
-						default_brush_action(input, output, session, heatmap_id, qq("Found nothing from heatmaps with keywords '@{keywords2}'."), selected = selected(), ht_list = ht_list())
-					}
+						if(do_default_brush_action) {
+							default_brush_action(input, output, session, heatmap_id, qq("Found nothing from heatmaps with keywords '@{keywords2}'."), selected = selected(), ht_list = ht_list())
+						}
 
-					if(!is.null(brush_action)) {
-						brush_action2(selected(), input, output, session)
+						if(!is.null(brush_action)) {
+							brush_action2(selected(), input, output, session)
+						}
+						return(invisible(NULL))
+					} else {
+						sub_ht_list( make_sub_heatmap(input, output, session, heatmap_id, selected = selected(), ht_list = ht_list()) )
 					}
-					return(invisible(NULL))
-	    		} else {
-	    			sub_ht_list( make_sub_heatmap(input, output, session, heatmap_id, selected = selected(), ht_list = ht_list()) )
-				}
-			}, res = res)
+				}, res = res)
+			}
 
 			if(do_default_brush_action) {
 				default_brush_action(input, output, session, heatmap_id, selected = selected(), ht_list = ht_list())
@@ -748,14 +796,22 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 			
 			req(heatmap_initialized())
 
-			output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
-				if(is.null(selected())) {
-	    			grid.newpage()
-					grid.text("Select an area of the heatmap", 0.5, 0.5, gp = gpar(fontsize = 14))
-	    		} else {
-	    			make_sub_heatmap(input, output, session, heatmap_id, update_size = FALSE, selected = selected(), ht_list = ht_list())
-				}
-			}, res = res)
+			message("(6)")
+			if (plotly) {
+				# output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot(plot(0))
+				output[[qq("@{heatmap_id}_sub_heatmap")]] = plotly::renderPlotly({
+					make_plotly_sub_heatmap(input, output, session, heatmap_id, update_size = FALSE, selected = selected, ht_list = ht_list)
+				})
+			} else {
+				output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+					if(is.null(selected())) {
+						grid.newpage()
+						grid.text("Select an area of the heatmap", 0.5, 0.5, gp = gpar(fontsize = 14))
+					} else {
+						make_sub_heatmap(input, output, session, heatmap_id, update_size = FALSE, selected = selected(), ht_list = ht_list())
+					}
+				}, res = res)
+			}
 		})
 
 		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_open_table")]] = observeEvent(input[[qq("@{heatmap_id}_open_table")]], {
@@ -1734,9 +1790,9 @@ default_click_action = function(input, output, session, heatmap_id, selected = N
 <div>
 <p>Details:</p>
 <pre>
-Target:     @{row_label}
+Target:  @{row_label}
 Sample:  @{column_label}
-Value:         @{v_chr} <span style='background-color:@{col};width=10px;'> </span>
+Value:   @{v_chr} <span style='background-color:@{col};width=10px;'> </span>
 <!--Gene Name:
 UniprotID:-->
 </pre>")
@@ -1906,3 +1962,61 @@ record_observation = function(obs, heatmap_id = shiny_env$current_heatmap_id) {
 	invisible(NULL)
 }
 
+# make a sub heatmap using plotly
+make_plotly_sub_heatmap = function(input, output, session, heatmap_id, update_size = TRUE, 
+	selected = NULL, ht_list = NULL, ...) {
+
+	if(is.null( selected() ))
+		return(NULL)
+
+	shiny_env$is_in_sub_heatmap = TRUE
+	on.exit(shiny_env$is_in_sub_heatmap <- FALSE)
+
+	width = session$clientData[[qq("output_@{heatmap_id}_sub_heatmap_width")]]
+    height = session$clientData[[qq("output_@{heatmap_id}_sub_heatmap_height")]]
+
+	message("Make plotly sub: H=", height, "px, W=", width, "px")
+
+	show_row_names = input[[qq("@{heatmap_id}_show_row_names_checkbox")]]
+	show_column_names = input[[qq("@{heatmap_id}_show_column_names_checkbox")]]
+	show_annotation = input[[qq("@{heatmap_id}_show_annotation_checkbox")]]
+	show_cell_fun = input[[qq("@{heatmap_id}_show_cell_fun_checkbox")]]
+	fill_figure = input[[qq("@{heatmap_id}_fill_figure_checkbox")]]
+
+	if(is.null(show_row_names)) show_row_names = TRUE
+	if(is.null(show_column_names)) show_column_names = TRUE
+	if(is.null(show_annotation)) show_annotation = TRUE
+	if(is.null(show_cell_fun)) show_cell_fun = TRUE
+	if(is.null(fill_figure)) fill_figure = FALSE
+
+
+
+	if(update_size) {
+		updateNumericInput(session, qq("@{heatmap_id}_sub_heatmap_input_width"), value = session$clientData[[qq("output_@{heatmap_id}_sub_heatmap_width")]])
+		updateNumericInput(session, qq("@{heatmap_id}_sub_heatmap_input_height"), value = session$clientData[[qq("output_@{heatmap_id}_sub_heatmap_height")]])
+	}
+
+	.make_plotly_sub_heatmap(ht_list, selected)
+}
+
+.make_plotly_sub_heatmap <- function(ht_list, selected) {
+	.r <- rev(selected()@listData$row_label@unlistData) # target
+	.c <- selected()@listData$column_label@unlistData # sample
+	.m_full <- ht_list()@ht_list$mat@matrix
+	.m <- .m_full[.r,.c] # value
+	.i <- paste0("Target: ", rep(.r, length(.c)), "\nSample: ", rep(.c, each=length(.r)), "\nValue: ", round(as.numeric(.m), 2))
+	dim(.i) <- dim(.m)
+	.col <- grDevices::colorRampPalette(ht_opt("COLOR"))(256)
+	range_full <- range(.m_full)
+	range_sub <- range(.m)
+	range_sub <- length(.col) * (range_sub - range_full[1]) / diff(range_full)
+	range_sub <- pmin(pmax(1, round(range_sub)), length(.col))
+	.col <- .col[range_sub[1]:range_sub[2]]
+	.p <- plotly::plot_ly(x = .c, y = .r, z = .m, type = "heatmap",
+		colors = .col,
+		hoverinfo = 'text', text = .i) |>
+		plotly::colorbar(thickness = 15, outlinewidth = 0, x = -0.5) |>
+		plotly::config(displayModeBar = FALSE) |>
+		plotly::layout(yaxis = list(side = "right"))
+	.p
+}

--- a/R/shiny-server.R
+++ b/R/shiny-server.R
@@ -342,7 +342,6 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 		}, res = res)
 
 
-		message("(0)")
 		if (plotly) {
 			output[[qq("@{heatmap_id}_sub_heatmap")]] = plotly::renderPlotly({
 				NULL
@@ -471,7 +470,6 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 
 			updateTextInput(session, qq("@{heatmap_id}_keyword"), value = "")
 
-			message("(1)")
 			if (plotly) {
 				# output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot(plot(0))
 				output[[qq("@{heatmap_id}_sub_heatmap")]] = plotly::renderPlotly({
@@ -515,7 +513,6 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 
 			selected(new_selected)
 
-			message("(2)")
 			if (plotly) {
 				# output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot(plot(0))
 				output[[qq("@{heatmap_id}_sub_heatmap")]] = plotly::renderPlotly({
@@ -560,7 +557,6 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 				selected( selected_copy() )
 			}
 			
-			message("(3)")
 			if (plotly) {
 				# output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot(plot(0))
 				output[[qq("@{heatmap_id}_sub_heatmap")]] = plotly::renderPlotly({
@@ -599,7 +595,6 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 
 			selected( selected_copy() )
 
-			message("(4)")
 			if (plotly) {
 				# output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot(plot(0))
 				output[[qq("@{heatmap_id}_sub_heatmap")]] = plotly::renderPlotly({
@@ -712,7 +707,6 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 			}
 			selected_copy( selected() )
 
-			message("(5)")
 			if (plotly) {
 				# output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot(plot(0))
 				output[[qq("@{heatmap_id}_sub_heatmap")]] = plotly::renderPlotly({
@@ -796,7 +790,6 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 			
 			req(heatmap_initialized())
 
-			message("(6)")
 			if (plotly) {
 				# output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot(plot(0))
 				output[[qq("@{heatmap_id}_sub_heatmap")]] = plotly::renderPlotly({

--- a/R/shiny-ui.R
+++ b/R/shiny-ui.R
@@ -134,11 +134,11 @@ InteractiveComplexHeatmapOutput = function(heatmap_id = NULL,
 		layout_css = qq("
 			.@{heatmap_id}_widget #@{heatmap_id}_heatmap_group {
 				display:table-cell;
-				vertical-align: middle;
+				vertical-align: top;
 			}
 			.@{heatmap_id}_widget #@{heatmap_id}_sub_heatmap_group {
 				display:table-cell;
-				vertical-align: middle;
+				vertical-align: top;
 			}
 		")
 
@@ -151,11 +151,11 @@ InteractiveComplexHeatmapOutput = function(heatmap_id = NULL,
 		layout_css = qq("
 			.@{heatmap_id}_widget #@{heatmap_id}_sub_heatmap_group {
 				display:table-cell;
-				vertical-align: middle;
+				vertical-align: top;
 			}
 			.@{heatmap_id}_widget #@{heatmap_id}_output_wrapper {
 				display:table-cell;
-				vertical-align: middle;
+				vertical-align: top;
 			}
 		")
 
@@ -168,15 +168,15 @@ InteractiveComplexHeatmapOutput = function(heatmap_id = NULL,
 		layout_css = qq("
 			.@{heatmap_id}_widget #@{heatmap_id}_heatmap_group {
 				display:table-cell;
-				vertical-align: middle;
+				vertical-align: top;
 			}
 			.@{heatmap_id}_widget #@{heatmap_id}_sub_heatmap_group {
 				display:table-cell;
-				vertical-align: middle;
+				vertical-align: top;
 			}
 			.@{heatmap_id}_widget #@{heatmap_id}_output_wrapper {
 				display:table-cell;
-				vertical-align: middle;
+				vertical-align: top;
 			}
 		")
 
@@ -196,7 +196,7 @@ InteractiveComplexHeatmapOutput = function(heatmap_id = NULL,
 		layout_css = qq("
 			.@{heatmap_id}_widget #@{heatmap_id}_heatmap_group {
 				display:table-cell;
-				vertical-align: middle;
+				vertical-align: top;
 			}
 		")
 
@@ -535,7 +535,7 @@ originalHeatmapOutput = function(heatmap_id, title = NULL,
 				$('#@{heatmap_id}_heatmap_input_width').val($('#@{heatmap_id}_heatmap').width());
 				$('#@{heatmap_id}_heatmap_input_height').val($('#@{heatmap_id}_heatmap').height());
 			")))
-		)	
+		)
 	)
 	main_heatmap_ui
 }
@@ -858,12 +858,11 @@ subHeatmapOutputPlotly = function(heatmap_id, title = NULL,
 				plotly::plotlyOutput(qq("@{heatmap_id}_sub_heatmap"), width = width, height = height)
 		    }
 		),
-		# vertical-align: middle;
 		tags$script(HTML(qq('
 			$("#@{heatmap_id}_sub_heatmap_resize").css("width", $("#@{heatmap_id}_sub_heatmap").width() + 4);
 			$("#@{heatmap_id}_sub_heatmap_resize").css("height", $("#@{heatmap_id}_sub_heatmap").height() + 4);
 		'))),
-		div(id = qq("@{heatmap_id}_sub_heatmap_control"),
+		shinyjs::hidden(div(id = qq("@{heatmap_id}_sub_heatmap_control"),
 			style = "display:none;",
 			tabsetPanel(
 			  id = qq('@{heatmap_id}_sub_tabs_panels'),
@@ -927,7 +926,7 @@ subHeatmapOutputPlotly = function(heatmap_id, title = NULL,
 				$('#@{heatmap_id}_sub_heatmap_input_width').val($('#@{heatmap_id}_sub_heatmap').width());
 				$('#@{heatmap_id}_sub_heatmap_input_height').val($('#@{heatmap_id}_sub_heatmap').height());
 			")))
-		),
+		)),
 		style = qq("width:@{width}; height:@{height};")
 	)
 

--- a/R/shiny-ui.R
+++ b/R/shiny-ui.R
@@ -55,6 +55,7 @@ InteractiveComplexHeatmapOutput = function(heatmap_id = NULL,
 	output_ui = default_output_ui(heatmap_id), 
 	output_ui_float = FALSE, containment = FALSE,
 	internal = FALSE, add_spinner = F, closable_output = T,
+	plotly = FALSE,
 	...) {
 
 	if(is.null(heatmap_id)) {
@@ -117,7 +118,11 @@ InteractiveComplexHeatmapOutput = function(heatmap_id = NULL,
 	main_heatmap_ui = originalHeatmapOutput(heatmap_id, title = title1, width = width1, height = height1, action = action,
 		cursor = cursor, response = response, brush_opt = brush_opt, containment = containment, internal = internal, add_spinner = add_spinner)
 
-	sub_heatmap_ui = subHeatmapOutput(heatmap_id, title = title2, width = width2, height = height2, containment = containment, internal = internal, add_spinner = add_spinner)
+	if (plotly) {
+		sub_heatmap_ui = subHeatmapOutputPlotly(heatmap_id, title = title2, width = width2, height = height2, containment = containment, internal = internal, add_spinner = add_spinner)
+	} else {
+		sub_heatmap_ui = subHeatmapOutput(heatmap_id, title = title2, width = width2, height = height2, containment = containment, internal = internal, add_spinner = add_spinner)
+	}
 
 	output_ui = HeatmapInfoOutput(heatmap_id, title = title3, width = width3, output_ui = output_ui, output_ui_float = output_ui_float,
 		action = action, response = response, internal = internal, closable = closable_output)
@@ -474,7 +479,7 @@ originalHeatmapOutput = function(heatmap_id, title = NULL,
 						),
 						p("Search Heatmap", style = "display:none;")
 					),
-					hidden(tabPanel(HTML("<i class='fa none'></i>"),
+					shinyjs::hidden(tabPanel(HTML("<i class='fa none'></i>"),
 					         div(
 					           id = qq('@{heatmap_id}_tabs-brush'),
 					           HTML(qq('
@@ -498,7 +503,7 @@ originalHeatmapOutput = function(heatmap_id, title = NULL,
 					           sliderInput(qq("@{heatmap_id}_color_pickers_opacity"), label = "Opacity", min = 0, max = 1, value = pickr_opacity)
 					         )
 					)),
-					hidden(tabPanel(HTML("<i class='fa none'></i>"),
+					shinyjs::hidden(tabPanel(HTML("<i class='fa none'></i>"),
 						div(
 							id = qq('@{heatmap_id}_tabs-save-image'),
 							radioButtons(qq("@{heatmap_id}_heatmap_download_format"), label = "File Format", choices = list("png" = 1, "pdf" = 2, "svg" = 3), selected = 1, inline = TRUE),
@@ -797,4 +802,125 @@ add_js_css_dep = function(heatmap_id, js_file, css_file, envir = parent.frame())
 		script     = "foo.js",
 		head = paste0(temp_js, "\n", temp_css)
     )
+}
+
+
+subHeatmapOutputPlotly = function(heatmap_id, title = NULL,
+	width = 400, height = 350, containment = FALSE, internal = FALSE, add_spinner = F) {
+
+	if(missing(heatmap_id)) {
+		if(length(shiny_env$heatmap) == 1) {
+			heatmap_id = names(shiny_env$heatmap)
+		} else if(length(shiny_env$heatmap) == 0) {
+			increase_widget_index()
+			heatmap_id = paste0("ht", get_widget_index())
+		}
+	}
+	if(is.null(shiny_env$heatmap[[heatmap_id]])) {
+		shiny_env$heatmap[[heatmap_id]] = list()
+		if(!internal) shiny_env$current_heatmap_id = heatmap_id
+	}
+
+	if(identical(containment, FALSE)) {
+		containment = "false"
+	} else if(identical(containment, TRUE)) {
+		containment = qq("$('#@{heatmap_id}_sub_heatmap_group').parent()")
+	} else {
+		containment = paste0('"', containment, '"')
+	}
+
+	layout = shiny_env$heatmap[[heatmap_id]]$layout
+	if(is.null(layout)) layout = ""
+
+	heatmap_hash = paste0("c", digest(heatmap_id, "crc32"))
+	sub_heatmap_ui = div(
+		id = qq("@{heatmap_id}_sub_heatmap_group"),
+		
+		add_js_css_dep(heatmap_id, js_file = "ht-sub.js", css_file = "ht-sub.css"),
+		
+		if(identical(title, NULL) || identical(title, "")) NULL else h5(title),
+		div(id = qq("@{heatmap_id}_sub_heatmap_resize"),
+		    if(add_spinner) {
+		      shinycssloaders::withSpinner(
+				# plotOutput(qq("@{heatmap_id}_sub_heatmap"), height = height, width = width)
+				plotly::plotlyOutput(qq("@{heatmap_id}_sub_heatmap"), width = width, height = height)
+				,type = 8, size = 0.3)
+		    } else {
+		    	# plotOutput(qq("@{heatmap_id}_sub_heatmap"), height = height, width = width)
+				plotly::plotlyOutput(qq("@{heatmap_id}_sub_heatmap"), width = width, height = height)
+		    }
+		),
+		tags$script(HTML(qq('
+			$("#@{heatmap_id}_sub_heatmap_resize").css("width", $("#@{heatmap_id}_sub_heatmap").width() + 4);
+			$("#@{heatmap_id}_sub_heatmap_resize").css("height", $("#@{heatmap_id}_sub_heatmap").height() + 4);
+		'))),
+		div(id = qq("@{heatmap_id}_sub_heatmap_control"),
+			style = "display:none;",
+			tabsetPanel(
+			  id = qq('@{heatmap_id}_sub_tabs_panels'),
+				tabPanel(HTML("<i class='fa fa-tasks'></i>"),
+					div(id = qq('@{heatmap_id}_sub_tabs-setting'), 
+						div(
+							div(checkboxInput(qq("@{heatmap_id}_show_row_names_checkbox"), label = "Show row names", value = TRUE), style = "float:left;width:150px"),
+							div(checkboxInput(qq("@{heatmap_id}_show_column_names_checkbox"), label = "Show column names", value = TRUE), style = "float:left;width:160px"),
+							div(style = "clear: both;")
+						),
+						div(
+							checkboxInput(qq("@{heatmap_id}_show_annotation_checkbox"), label = "Show heatmap annotations", value = TRUE),
+							checkboxInput(qq("@{heatmap_id}_show_cell_fun_checkbox"), label = "Show cell decorations", value = TRUE),
+							checkboxInput(qq("@{heatmap_id}_fill_figure_checkbox"), label = "Fill figure region", value = FALSE)
+						),
+						hr(),
+						div(
+							checkboxInput(qq("@{heatmap_id}_remove_empty_checkbox"), label = "Remove empty rows and columns", value = FALSE),
+							HTML(qq('
+						<p style="padding-top:4px;">
+						Remove <input id="@{heatmap_id}_post_remove" type="number" class="form-control" min="1" value="1" style="width:60px;display:inline;"/>
+						<span id="@{heatmap_id}_post_remove_which">rows</span> from 
+						<select id="@{heatmap_id}_post_remove_dimension" class="form-control" style="width:auto;display:inline;">
+						<option value="top" selected>top</option>
+						<option value="bottom">bottom</option>
+						<option value="left">left</option>
+						<option value="right">right</option></select>
+						</p>
+							')),
+							actionButton(qq("@{heatmap_id}_post_remove_submit"), "Remove", class = "btn btn-danger"),
+							actionButton(qq("@{heatmap_id}_post_remove_reset"), "Reset", class = "btn btn-primary"),
+							tags$script(HTML(qq("
+								$('#@{heatmap_id}_post_remove_dimension').change(function() {
+									if($(this).val() == 1 || $(this).val() == 2) {
+										$('#@{heatmap_id}_post_remove_which').text('rows');
+									} else {
+										$('#@{heatmap_id}_post_remove_which').text('columns');
+									}
+								});
+							")))
+						)
+					)
+				),
+				tabPanel(HTML("<i class='fa fa-table'></i>"),
+					div(id = qq("@{heatmap_id}_sub_tabs-table"),
+						actionButton(qq("@{heatmap_id}_open_table"), label = "Export Sub-Heatmap Table", class = "btn btn-primary")
+					)
+				),
+				tabPanel(HTML("<i class='fa fa-images'></i>"),
+					div(id = qq('@{heatmap_id}_sub_tabs-save-image'),
+						radioButtons(qq("@{heatmap_id}_sub_heatmap_download_format"), label = "File Format", choices = list("png" = 1, "pdf" = 2, "svg" = 3), selected = 1, inline = TRUE),
+						numericInput(qq("@{heatmap_id}_sub_heatmap_download_image_width"), label = "Image width (in px)", value = 0),
+						numericInput(qq("@{heatmap_id}_sub_heatmap_download_image_height"), label = "Image height (in px)", value = 0),
+						downloadButton(qq("@{heatmap_id}_sub_heatmap_download_button"), "Save image", class = "btn btn-primary")
+					),
+				)
+			),
+			tags$script(HTML(qq("
+				$('#@{heatmap_id}_sub_heatmap_download_image_width').val($('#@{heatmap_id}_sub_heatmap').width());
+				$('#@{heatmap_id}_sub_heatmap_download_image_height').val($('#@{heatmap_id}_sub_heatmap').height());
+				$('#@{heatmap_id}_sub_heatmap_input_width').val($('#@{heatmap_id}_sub_heatmap').width());
+				$('#@{heatmap_id}_sub_heatmap_input_height').val($('#@{heatmap_id}_sub_heatmap').height());
+			")))
+		),
+		style = qq("width:@{width}; height:@{height};")
+	)
+
+	sub_heatmap_ui
 }

--- a/R/shiny-ui.R
+++ b/R/shiny-ui.R
@@ -605,6 +605,19 @@ subHeatmapOutput = function(heatmap_id, title = NULL,
 			style = "display:none;",
 			tabsetPanel(
 			  id = qq('@{heatmap_id}_sub_tabs_panels'),
+				tabPanel(HTML("<i class='fa fa-table'></i>"),
+					div(id = qq("@{heatmap_id}_sub_tabs-table"),
+						actionButton(qq("@{heatmap_id}_open_table"), label = "Export Sub-Heatmap Table", class = "btn btn-primary")
+					)
+				),
+				tabPanel(HTML("<i class='fa fa-images'></i>"),
+					div(id = qq('@{heatmap_id}_sub_tabs-save-image'),
+						radioButtons(qq("@{heatmap_id}_sub_heatmap_download_format"), label = "File Format", choices = list("png" = 1, "pdf" = 2, "svg" = 3), selected = 1, inline = TRUE),
+						numericInput(qq("@{heatmap_id}_sub_heatmap_download_image_width"), label = "Image width (in px)", value = 0),
+						numericInput(qq("@{heatmap_id}_sub_heatmap_download_image_height"), label = "Image height (in px)", value = 0),
+						downloadButton(qq("@{heatmap_id}_sub_heatmap_download_button"), "Save image", class = "btn btn-primary")
+					),
+				),
 				tabPanel(HTML("<i class='fa fa-tasks'></i>"),
 					div(id = qq('@{heatmap_id}_sub_tabs-setting'), 
 						div(
@@ -644,19 +657,6 @@ subHeatmapOutput = function(heatmap_id, title = NULL,
 							")))
 						)
 					)
-				),
-				tabPanel(HTML("<i class='fa fa-table'></i>"),
-					div(id = qq("@{heatmap_id}_sub_tabs-table"),
-						actionButton(qq("@{heatmap_id}_open_table"), label = "Export Sub-Heatmap Table", class = "btn btn-primary")
-					)
-				),
-				tabPanel(HTML("<i class='fa fa-images'></i>"),
-					div(id = qq('@{heatmap_id}_sub_tabs-save-image'),
-						radioButtons(qq("@{heatmap_id}_sub_heatmap_download_format"), label = "File Format", choices = list("png" = 1, "pdf" = 2, "svg" = 3), selected = 1, inline = TRUE),
-						numericInput(qq("@{heatmap_id}_sub_heatmap_download_image_width"), label = "Image width (in px)", value = 0),
-						numericInput(qq("@{heatmap_id}_sub_heatmap_download_image_height"), label = "Image height (in px)", value = 0),
-						downloadButton(qq("@{heatmap_id}_sub_heatmap_download_button"), "Save image", class = "btn btn-primary")
-					),
 				)
 			),
 			tags$script(HTML(qq("
@@ -862,50 +862,10 @@ subHeatmapOutputPlotly = function(heatmap_id, title = NULL,
 			$("#@{heatmap_id}_sub_heatmap_resize").css("width", $("#@{heatmap_id}_sub_heatmap").width() + 4);
 			$("#@{heatmap_id}_sub_heatmap_resize").css("height", $("#@{heatmap_id}_sub_heatmap").height() + 4);
 		'))),
-		shinyjs::hidden(div(id = qq("@{heatmap_id}_sub_heatmap_control"),
+		div(id = qq("@{heatmap_id}_sub_heatmap_control"),
 			style = "display:none;",
 			tabsetPanel(
 			  id = qq('@{heatmap_id}_sub_tabs_panels'),
-				tabPanel(HTML("<i class='fa fa-tasks'></i>"),
-					div(id = qq('@{heatmap_id}_sub_tabs-setting'), 
-						div(
-							div(checkboxInput(qq("@{heatmap_id}_show_row_names_checkbox"), label = "Show row names", value = TRUE), style = "float:left;width:150px"),
-							div(checkboxInput(qq("@{heatmap_id}_show_column_names_checkbox"), label = "Show column names", value = TRUE), style = "float:left;width:160px"),
-							div(style = "clear: both;")
-						),
-						div(
-							checkboxInput(qq("@{heatmap_id}_show_annotation_checkbox"), label = "Show heatmap annotations", value = TRUE),
-							checkboxInput(qq("@{heatmap_id}_show_cell_fun_checkbox"), label = "Show cell decorations", value = TRUE),
-							checkboxInput(qq("@{heatmap_id}_fill_figure_checkbox"), label = "Fill figure region", value = FALSE)
-						),
-						hr(),
-						div(
-							checkboxInput(qq("@{heatmap_id}_remove_empty_checkbox"), label = "Remove empty rows and columns", value = FALSE),
-							HTML(qq('
-						<p style="padding-top:4px;">
-						Remove <input id="@{heatmap_id}_post_remove" type="number" class="form-control" min="1" value="1" style="width:60px;display:inline;"/>
-						<span id="@{heatmap_id}_post_remove_which">rows</span> from 
-						<select id="@{heatmap_id}_post_remove_dimension" class="form-control" style="width:auto;display:inline;">
-						<option value="top" selected>top</option>
-						<option value="bottom">bottom</option>
-						<option value="left">left</option>
-						<option value="right">right</option></select>
-						</p>
-							')),
-							actionButton(qq("@{heatmap_id}_post_remove_submit"), "Remove", class = "btn btn-danger"),
-							actionButton(qq("@{heatmap_id}_post_remove_reset"), "Reset", class = "btn btn-primary"),
-							tags$script(HTML(qq("
-								$('#@{heatmap_id}_post_remove_dimension').change(function() {
-									if($(this).val() == 1 || $(this).val() == 2) {
-										$('#@{heatmap_id}_post_remove_which').text('rows');
-									} else {
-										$('#@{heatmap_id}_post_remove_which').text('columns');
-									}
-								});
-							")))
-						)
-					)
-				),
 				tabPanel(HTML("<i class='fa fa-table'></i>"),
 					div(id = qq("@{heatmap_id}_sub_tabs-table"),
 						actionButton(qq("@{heatmap_id}_open_table"), label = "Export Sub-Heatmap Table", class = "btn btn-primary")
@@ -918,7 +878,47 @@ subHeatmapOutputPlotly = function(heatmap_id, title = NULL,
 						numericInput(qq("@{heatmap_id}_sub_heatmap_download_image_height"), label = "Image height (in px)", value = 0),
 						downloadButton(qq("@{heatmap_id}_sub_heatmap_download_button"), "Save image", class = "btn btn-primary")
 					),
-				)
+				),
+				# tabPanel(HTML("<i class='fa fa-tasks'></i>"),
+				# 	div(id = qq('@{heatmap_id}_sub_tabs-setting'), 
+				# 		div(
+				# 			div(checkboxInput(qq("@{heatmap_id}_show_row_names_checkbox"), label = "Show row names", value = TRUE), style = "float:left;width:150px"),
+				# 			div(checkboxInput(qq("@{heatmap_id}_show_column_names_checkbox"), label = "Show column names", value = TRUE), style = "float:left;width:160px"),
+				# 			div(style = "clear: both;")
+				# 		),
+				# 		div(
+				# 			checkboxInput(qq("@{heatmap_id}_show_annotation_checkbox"), label = "Show heatmap annotations", value = TRUE),
+				# 			checkboxInput(qq("@{heatmap_id}_show_cell_fun_checkbox"), label = "Show cell decorations", value = TRUE),
+				# 			checkboxInput(qq("@{heatmap_id}_fill_figure_checkbox"), label = "Fill figure region", value = FALSE)
+				# 		),
+				# 		hr(),
+				# 		div(
+				# 			checkboxInput(qq("@{heatmap_id}_remove_empty_checkbox"), label = "Remove empty rows and columns", value = FALSE),
+				# 			HTML(qq('
+				# 		<p style="padding-top:4px;">
+				# 		Remove <input id="@{heatmap_id}_post_remove" type="number" class="form-control" min="1" value="1" style="width:60px;display:inline;"/>
+				# 		<span id="@{heatmap_id}_post_remove_which">rows</span> from 
+				# 		<select id="@{heatmap_id}_post_remove_dimension" class="form-control" style="width:auto;display:inline;">
+				# 		<option value="top" selected>top</option>
+				# 		<option value="bottom">bottom</option>
+				# 		<option value="left">left</option>
+				# 		<option value="right">right</option></select>
+				# 		</p>
+				# 			')),
+				# 			actionButton(qq("@{heatmap_id}_post_remove_submit"), "Remove", class = "btn btn-danger"),
+				# 			actionButton(qq("@{heatmap_id}_post_remove_reset"), "Reset", class = "btn btn-primary"),
+				# 			tags$script(HTML(qq("
+				# 				$('#@{heatmap_id}_post_remove_dimension').change(function() {
+				# 					if($(this).val() == 1 || $(this).val() == 2) {
+				# 						$('#@{heatmap_id}_post_remove_which').text('rows');
+				# 					} else {
+				# 						$('#@{heatmap_id}_post_remove_which').text('columns');
+				# 					}
+				# 				});
+				# 			")))
+				# 		)
+				# 	)
+				# )
 			),
 			tags$script(HTML(qq("
 				$('#@{heatmap_id}_sub_heatmap_download_image_width').val($('#@{heatmap_id}_sub_heatmap').width());
@@ -926,7 +926,7 @@ subHeatmapOutputPlotly = function(heatmap_id, title = NULL,
 				$('#@{heatmap_id}_sub_heatmap_input_width').val($('#@{heatmap_id}_sub_heatmap').width());
 				$('#@{heatmap_id}_sub_heatmap_input_height').val($('#@{heatmap_id}_sub_heatmap').height());
 			")))
-		)),
+		),
 		style = qq("width:@{width}; height:@{height};")
 	)
 

--- a/R/shiny-ui.R
+++ b/R/shiny-ui.R
@@ -134,9 +134,11 @@ InteractiveComplexHeatmapOutput = function(heatmap_id = NULL,
 		layout_css = qq("
 			.@{heatmap_id}_widget #@{heatmap_id}_heatmap_group {
 				display:table-cell;
+				vertical-align: middle;
 			}
 			.@{heatmap_id}_widget #@{heatmap_id}_sub_heatmap_group {
 				display:table-cell;
+				vertical-align: middle;
 			}
 		")
 
@@ -149,9 +151,11 @@ InteractiveComplexHeatmapOutput = function(heatmap_id = NULL,
 		layout_css = qq("
 			.@{heatmap_id}_widget #@{heatmap_id}_sub_heatmap_group {
 				display:table-cell;
+				vertical-align: middle;
 			}
 			.@{heatmap_id}_widget #@{heatmap_id}_output_wrapper {
 				display:table-cell;
+				vertical-align: middle;
 			}
 		")
 
@@ -164,12 +168,15 @@ InteractiveComplexHeatmapOutput = function(heatmap_id = NULL,
 		layout_css = qq("
 			.@{heatmap_id}_widget #@{heatmap_id}_heatmap_group {
 				display:table-cell;
+				vertical-align: middle;
 			}
 			.@{heatmap_id}_widget #@{heatmap_id}_sub_heatmap_group {
 				display:table-cell;
+				vertical-align: middle;
 			}
 			.@{heatmap_id}_widget #@{heatmap_id}_output_wrapper {
 				display:table-cell;
+				vertical-align: middle;
 			}
 		")
 
@@ -189,6 +196,7 @@ InteractiveComplexHeatmapOutput = function(heatmap_id = NULL,
 		layout_css = qq("
 			.@{heatmap_id}_widget #@{heatmap_id}_heatmap_group {
 				display:table-cell;
+				vertical-align: middle;
 			}
 		")
 
@@ -850,6 +858,7 @@ subHeatmapOutputPlotly = function(heatmap_id, title = NULL,
 				plotly::plotlyOutput(qq("@{heatmap_id}_sub_heatmap"), width = width, height = height)
 		    }
 		),
+		# vertical-align: middle;
 		tags$script(HTML(qq('
 			$("#@{heatmap_id}_sub_heatmap_resize").css("width", $("#@{heatmap_id}_sub_heatmap").width() + 4);
 			$("#@{heatmap_id}_sub_heatmap_resize").css("height", $("#@{heatmap_id}_sub_heatmap").height() + 4);

--- a/inst/_tmp/index.R
+++ b/inst/_tmp/index.R
@@ -4,8 +4,8 @@ library(shiny)
 
 devtools::load_all()
 
-nr <- 15
-nc <- 20
+nr <- 5
+nc <- 10
 sc <- 5
 set.seed(0)
 X <- matrix(runif(nr * nc, -1, 1), nr, nc)
@@ -14,14 +14,17 @@ dimnames(X) <- list(paste0("r_", 1:nr), paste0("c_", 1:nc))
 use_plotly=T
 
 ui <- fluidPage(
+    tags$style('.container-fluid {background-color: #ff006644;}'),
+    # tags$style("html {background-color: black}"),
     h3("My first interactive ComplexHeatmap Shiny app"),
     p("This is an interactive heatmap visualization on a random matrix."),
     InteractiveComplexHeatmapOutput(
         title1 = "", title2 = "",
-        width1 = 690, height1 = 500,
-        width2 = 290, height2 = 500,
+        width1 = 690, height1 = 400,
+        width2 = 290, height2 = 400,
         containment = TRUE,
-        output_ui_float = FALSE, layout="1-3", title3=NULL, closable_output = FALSE,
+        output_ui_float = FALSE, layout="1-3", 
+        title3=NULL, closable_output = FALSE,
         add_spinner = TRUE,
         plotly = use_plotly)
 )
@@ -36,18 +39,5 @@ server <- function(input, output, session) {
     makeInteractiveComplexHeatmap(input, output, session, ht1, plotly = use_plotly)
 }
 
+# op <- par(bg="transparent")
 shinyApp(ui, server, options = list(port = 8080))
-
-
-# .r =LETTERS[1:3] # target
-# .c = letters[1:5] # sample
-# .m <- matrix(1:15,3,5)
-# .i <- paste0("Target: ", rep(.r, length(.c)), "\nSample: ", rep(.c, each=length(.r)), "\nValue: ", as.numeric(.m))
-# dim(.i) <- dim(.m)
-
-# .f <- plotly::plot_ly(x = .c, y = .r, z = .m, type = "heatmap", hoverinfo = 'text', text = .i)
-# 					# colors = grDevices::colorRampPalette(ht_opt("COLOR"))(256),
-# 					hoverinfo = 'text', text = .i)
-
-## TODO:
-## - position is off whenever the sub heatmap group is shown

--- a/inst/_tmp/index.R
+++ b/inst/_tmp/index.R
@@ -4,12 +4,16 @@ library(shiny)
 
 devtools::load_all()
 
-data(rand_mat) # simply a random matrix
-ht1 = Heatmap(rand_mat, name = "mat",
-    show_row_names = TRUE, show_column_names = TRUE, row_title_rot = 0)
-ht1 = draw(ht1)
+nr <- 15
+nc <- 20
+sc <- 5
+set.seed(0)
+X <- matrix(runif(nr * nc, -1, 1), nr, nc)
+dimnames(X) <- list(paste0("r_", 1:nr), paste0("c_", 1:nc))
 
-ui = fluidPage(
+use_plotly=T
+
+ui <- fluidPage(
     h3("My first interactive ComplexHeatmap Shiny app"),
     p("This is an interactive heatmap visualization on a random matrix."),
     InteractiveComplexHeatmapOutput(
@@ -18,11 +22,32 @@ ui = fluidPage(
         width2 = 290, height2 = 500,
         containment = TRUE,
         output_ui_float = FALSE, layout="1-3", title3=NULL, closable_output = FALSE,
-        add_spinner = TRUE)
+        add_spinner = TRUE,
+        plotly = use_plotly)
 )
 
-server = function(input, output, session) {
-    makeInteractiveComplexHeatmap(input, output, session, ht1)
+server <- function(input, output, session) {
+    # ht1 <- Heatmap(X, name = "mat",
+    #     show_row_names = TRUE, show_column_names = TRUE, row_title_rot = 0,
+    #     row_names_gp = gpar(fontsize = sc),
+    #     column_names_gp = gpar(fontsize = sc))
+    ht1 <- Heatmap(X, name = "mat",
+        show_row_names = TRUE, show_column_names = TRUE, row_title_rot = 0)
+    makeInteractiveComplexHeatmap(input, output, session, ht1, plotly = use_plotly)
 }
 
-shinyApp(ui, server)
+shinyApp(ui, server, options = list(port = 8080))
+
+
+# .r =LETTERS[1:3] # target
+# .c = letters[1:5] # sample
+# .m <- matrix(1:15,3,5)
+# .i <- paste0("Target: ", rep(.r, length(.c)), "\nSample: ", rep(.c, each=length(.r)), "\nValue: ", as.numeric(.m))
+# dim(.i) <- dim(.m)
+
+# .f <- plotly::plot_ly(x = .c, y = .r, z = .m, type = "heatmap", hoverinfo = 'text', text = .i)
+# 					# colors = grDevices::colorRampPalette(ht_opt("COLOR"))(256),
+# 					hoverinfo = 'text', text = .i)
+
+## TODO:
+## - position is off whenever the sub heatmap group is shown

--- a/inst/template/ht-sub.js
+++ b/inst/template/ht-sub.js
@@ -107,14 +107,14 @@ $(function() {
 
 	
 	var objs2 = $('#@{heatmap_id}_sub_heatmap_control li a');
-	$(objs2[0]).attr("title", "Configure sub-heatmap");
-	$(objs2[1]).attr("title", "Export to table");
-	$(objs2[2]).attr("title", "Save sub-heatmap as an image");
+	$(objs2[0]).attr("title", "Export to table");
+	$(objs2[1]).attr("title", "Save sub-heatmap as an image");
+	$(objs2[2]).attr("title", "Configure sub-heatmap");
 	$(objs2[3]).attr("title", "Resize sub-heatmap");
 
-	var href = $(objs2[0]).attr("href");
+	var href = $(objs2[2]).attr("href");
 	$(href).attr("visible", "0")
-	$(objs2[0]).css("background-color", "white");
+	$(objs2[2]).css("background-color", "white");
 	$(href).parent().css("display", "none");
 
 	for(var i = 0; i < objs2.length; i ++) {


### PR DESCRIPTION
Plotly implementation for sub heatmap while keeping the main heatmap an interactive complex heatmap (png from the graphics devide). The plotly subheatmap is adjusted in the following ways:

- row/col labels appear on the same sides as the main heatmap & color bar is moved to the top left
- color scale is the same as the main heatmap and the range is adjusted based on the selection so that the cell colors match that of the main heatmap
- the cell hover info brings up the same info as the click on the main heatmap (without the colored rectangle)
- you can zoom in on the plotly heatmap even further